### PR TITLE
Ignore system files for Mac OS and PyCharm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 devel
 
 profile.tmp
+
+.DS_Store
+.idea/


### PR DESCRIPTION
## What? / Why?
Adds .DS_Store and .idea/ name to .gitignore to prevent git from
tracking these files as they are not related to a project.





[ ] - works on simulator
[ ] - tested locally
[ ] - `local env version: Mac OS High Sierra version 10.13.3 (17D102)`
